### PR TITLE
Fix possible typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git submodule add https://github.com/caressofsteel/hugo-story.git themes/hugo-st
 ### 4. Copy `data` and `config.toml` with overwrite from `exampleSite`
 ```
 cp -r themes/hugo-story/exampleSite/data ./
-cp themes/hugo-story/exampleSite/config.toml/
+cp themes/hugo-story/exampleSite/config.toml ./
 ```
 > _Hint: Using `config.toml` tells Hugo to use the theme and sets some basic theme parameters._
 


### PR DESCRIPTION
The current instructions for copying the `config.toml` is this:

```
cp themes/hugo-story/exampleSite/config.toml/
``` 

But that turned out be an error when I tried it. This gets printed out in the terminal:

```
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
```

I believe the correct instruction is this:

```
cp themes/hugo-story/exampleSite/config.toml ./
```