### PR TITLE
warning during build:

### DIFF
--- a/assets/sass/libs/_breakpoints.scss
+++ b/assets/sass/libs/_breakpoints.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: null;
 
 // Mixins.
 


### PR DESCRIPTION
!global assignments won't be able to declare new variables in future versions.
Consider adding `$breakpoints: null` at the top level.