### PR TITLE
Add lightbox support for modern image formats

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -236,7 +236,7 @@
 						href = $a.attr('href');
 
 					// Not an image? Bail.
-						if (!href.match(/\.(jpg|gif|png|mp4)$/))
+						if (!href.match(/\.(jpg|gif|png|mp4|webp|avif)$/))
 							return;
 
 					// Prevent default.


### PR DESCRIPTION
Right now, if one uses webp or avif for image formats, the gallery lightbox does not work correctly (loads the asset directly). This updates the filter so that the lightbox will present modern image formats correctly. Tested in local branch. 