### PR TITLE
Remove references to GA templates

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,8 +17,6 @@
 		<!-- Wrapper -->
 		</div>
 		
-		{{ template "_internal/google_analytics.html" . }}
-		{{ template "_internal/google_analytics_async.html" . }}	
 		{{ partial "scripts" . }}
 
 	</body>


### PR DESCRIPTION
Fixes #issue48.

Note comment that the theme has never included GA templates. Removing these calls lets `Hugo server` proceed and fixes the Usage instructions. 