### PR TITLE
google_analytics_async deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/exampleSite/layouts/_default/baseof.html
+++ b/exampleSite/layouts/_default/baseof.html
@@ -18,7 +18,6 @@
 		</div>
 		
 		{{ template "_internal/google_analytics.html" . }}
-		{{ template "_internal/google_analytics_async.html" . }}	
 		{{ partial "scripts" . }}
 
 	</body>


### PR DESCRIPTION
Hi! Thanks for your theme. This request solves this: https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410