### PR TITLE
Fix deprecation warning emitted from hugo 0.128.x

### DIFF
--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,2 @@
+.hugo_build.lock
+resources/

--- a/exampleSite/layouts/partials/head.html
+++ b/exampleSite/layouts/partials/head.html
@@ -9,14 +9,14 @@
 	{{ end }}
 	
 	<!-- CSS -->
-	{{ if .Site.IsServer }}
+	{{ if hugo.IsServer }}
 	{{ $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | toCSS (dict "targetPath" "css/main.css" "outputStyle" "compressed" "enableSourceMap" false) }}
 	<link rel="stylesheet" href="{{ ($style).RelPermalink }}">
 	{{ else }}
 	{{ $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | toCSS (dict "targetPath" "css/main.css" "enableSourceMap" false) }}
 	<link rel="stylesheet" href="{{ ($style | minify).RelPermalink }}">
 	{{ end }}
-	{{ if .Site.IsServer }}
+	{{ if hugo.IsServer }}
 	{{ $noscript := resources.Get "sass/noscript.scss" | resources.ExecuteAsTemplate "noscript.scss" . | toCSS (dict "targetPath" "css/noscript.css" "enableSourceMap" false) }}
 	<noscript><link rel="stylesheet" href="{{ ($noscript).RelPermalink }}" /></noscript>
 	{{ else }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,14 +9,14 @@
 	{{ end }}
 	
 	<!-- CSS -->
-	{{ if .Site.IsServer }}
+	{{ if hugo.IsServer }}
 	{{ $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | toCSS (dict "targetPath" "css/main.css" "outputStyle" "compressed" "enableSourceMap" false) }}
 	<link rel="stylesheet" href="{{ ($style).RelPermalink }}">
 	{{ else }}
 	{{ $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | toCSS (dict "targetPath" "css/main.css" "enableSourceMap" false) }}
 	<link rel="stylesheet" href="{{ ($style | minify).RelPermalink }}">
 	{{ end }}
-	{{ if .Site.IsServer }}
+	{{ if hugo.IsServer }}
 	{{ $noscript := resources.Get "sass/noscript.scss" | resources.ExecuteAsTemplate "noscript.scss" . | toCSS (dict "targetPath" "css/noscript.css" "enableSourceMap" false) }}
 	<noscript><link rel="stylesheet" href="{{ ($noscript).RelPermalink }}" /></noscript>
 	{{ else }}


### PR DESCRIPTION
This PR fixes a deprecation warning emitted from hugo 0.128.x:

```
WARN  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release.
Use hugo.IsServer instead.
```