### PR TITLE
Improve .gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,18 @@ Temporary Items
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+# Hugo
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+hugo.exe
+hugo.darwin
+hugo.linux
+/.hugo_build.lock
+
+# Misc
+.cache
+.DS_Store
+*.lock

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,2 +1,14 @@
-.hugo_build.lock
-resources/
+# Hugo
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+hugo.exe
+hugo.darwin
+hugo.linux
+/.hugo_build.lock
+
+# Misc
+.cache
+.DS_Store
+*.lock


### PR DESCRIPTION
This PR improves the .gitignore files to also ignore the `/public/` directory containing Hugo's generated files. I also added the ignores for Hugo's binaries and MacOS `.DS_Store`.